### PR TITLE
🛠 Add arlocal support for AvatarURL, improve find() results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 /lib
 dist
 scratch
+.DS_Store

--- a/src/Cache/Node.ts
+++ b/src/Cache/Node.ts
@@ -1,4 +1,4 @@
-import { ArAccount, T_addr, T_item } from '../types';
+import { ArAccount, GatewayConfig, T_addr, T_item } from '../types';
 import CacheAPI from './CacheAPI';
 import Data from '../data';
 
@@ -8,10 +8,10 @@ export default class Memory implements CacheAPI {
   private size: number;
   private data: Data;
 
-  constructor(size: number, expirationTime: number, gatewayHost: string) {
+  constructor(size: number, expirationTime: number, gatewayConfig: GatewayConfig) {
     this.expirationTime = expirationTime;
     this.size = size;
-    this.data = new Data(gatewayHost);
+    this.data = new Data(gatewayConfig);
   }
 
   get(addr: T_addr) {

--- a/src/Cache/Web.ts
+++ b/src/Cache/Web.ts
@@ -1,4 +1,4 @@
-import { T_item, ArAccount, T_addr } from '../types';
+import { T_item, ArAccount, T_addr, GatewayConfig } from '../types';
 import Cache from './CacheAPI';
 import Data from '../data';
 
@@ -7,10 +7,10 @@ export default class LocalStorage implements Cache {
   private size: number;
   private data: Data;
 
-  constructor(size: number, expirationTime: number, gatewayHost: string) {
+  constructor(size: number, expirationTime: number, gatewayConfig: GatewayConfig) {
     this.expirationTime = expirationTime;
     this.size = size;
-    this.data = new Data(gatewayHost);
+    this.data = new Data(gatewayConfig);
 
     if (!localStorage.getItem('arweave-account')) localStorage.setItem('arweave-account', '[]');
   }

--- a/src/Cache/index.ts
+++ b/src/Cache/index.ts
@@ -1,5 +1,5 @@
 import CacheAPI from './CacheAPI';
-import { ArAccount, T_addr } from '../types';
+import { ArAccount, GatewayConfig, T_addr } from '../types';
 import LocalStorage from './Web';
 import Memory from './Node';
 
@@ -7,12 +7,12 @@ export default class Cache implements CacheAPI {
   private cacheObj: { [K: string]: () => any } | CacheAPI;
   private size: number;
   private expirationTime: number;
-  private gatewayHost: string;
+  private gatewayConfig: GatewayConfig;
 
-  constructor(env: string | CacheAPI, size: number, expirationTime: number, gatewayHost: string) {
+  constructor(env: string | CacheAPI, size: number, expirationTime: number, gatewayConfig:GatewayConfig) {
     this.size = size;
     this.expirationTime = expirationTime;
-    this.gatewayHost = gatewayHost;
+    this.gatewayConfig = gatewayConfig;
 
     if (typeof env === 'object') this.cacheObj = env;
     else if (this.select[env]) this.cacheObj = this.select[env]();
@@ -21,8 +21,8 @@ export default class Cache implements CacheAPI {
 
   // Environments list
   private select: { [K: string]: () => any } = {
-    web: () => new LocalStorage(this.size, this.expirationTime, this.gatewayHost),
-    node: () => new Memory(this.size, this.expirationTime, this.gatewayHost),
+    web: () => new LocalStorage(this.size, this.expirationTime, this.gatewayConfig),
+    node: () => new Memory(this.size, this.expirationTime, this.gatewayConfig),
   };
 
   public get = (addr: string): ArAccount | undefined => this.cacheObj.get(addr);

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,28 +1,29 @@
-import { ArAccount, ArAccountEncoded, T_addr, T_profile, T_txid } from "./types";
+import { ArAccount, ArAccountEncoded, GatewayConfig, T_addr, T_profile, T_txid } from "./types";
 import { DEFAULT_AVATAR_URI, DEFAULT_BANNER_URI } from "./config";
 
 export default class Data {
 
-  private gatewayHost: string;
+  private gatewayConfig: GatewayConfig;
 
-  constructor(gatewayHost: string) {
-    this.gatewayHost = gatewayHost;
+  constructor(gatewayConfig: GatewayConfig) {
+    this.gatewayConfig = gatewayConfig;
   }
 
   private getURLfromURI(URI: string) {
     let ressource;
+    const gc = this.gatewayConfig;
     // Look for simple txids to be compatible with arweave account protocol v0.2
     if(/^[a-zA-Z0-9\-_]{43}$/.test(URI))
-      return "https://" + this.gatewayHost + "/" + URI;
+      return `${gc.protocol}://${gc.host}:${gc.port}/${URI}`;
     // ar://<txid>
     else if(ressource = URI.match(/^ar:\/\/([a-zA-Z0-9\-_]{43})$/))
-      return "https://" + this.gatewayHost + "/" + ressource[1];
+      return `${gc.protocol}://${gc.host}:${gc.port}/${ressource[1]}`;
     // http URLs
     else if(/^https?:\/\/.+$/.test(URI))
       return URI;
     // corrupted data (default avatar)
     else
-      return "https://" + this.gatewayHost + "/" + DEFAULT_AVATAR_URI;
+      return `${gc.protocol}://${gc.host}:${gc.port}/${DEFAULT_AVATAR_URI}`;
   }
 
   private getUniqueHandle(addr: T_addr, handleName?: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import Arweave from 'arweave';
 import ArDB from 'ardb';
-import { ArAccount, T_addr, T_profile, T_txid } from './types';
+import { ArAccount, T_addr, T_profile, T_txid, GatewayConfig } from './types';
 import transaction from 'ardb/lib/models/transaction';
 import block from 'ardb/lib/models/block';
 import Cache from './Cache';
@@ -21,7 +21,7 @@ export default class Account {
     cacheIsActivated = true,
     cacheSize = 100,
     cacheTime = 60000,
-    gateway = {
+    gateway = <GatewayConfig>{
       host: 'arweave.net', // Hostname or IP address for a Arweave host
       port: 443, // Port
       protocol: 'https', // Network protocol http or https
@@ -31,12 +31,12 @@ export default class Account {
   } = {}) {
     this.arweave = Arweave.init(gateway);
     this.ardb = new ArDB(this.arweave);
-    this.data = new Data(gateway.host);
+    this.data = new Data(gateway);
 
     if (cacheIsActivated) {
       if (typeof window !== 'undefined') {
-        this.cache = new Cache('web', cacheSize, cacheTime, gateway.host);
-      } else this.cache = new Cache('node', cacheSize, cacheTime, gateway.host);
+        this.cache = new Cache('web', cacheSize, cacheTime, gateway);
+      } else this.cache = new Cache('node', cacheSize, cacheTime, gateway);
     } else this.cache = null;
   }
 
@@ -164,12 +164,13 @@ export default class Account {
       });
 
       const a = await Promise.all(formattedAccounts);
-      const accounts = a.filter((e): e is ArAccount => e !== undefined);
-
-      if (accounts.length > 0) {
-        this.cache?.hydrate(accounts[0].addr, accounts[0]);
-        return accounts[0];
-      } else return null;
+      const accounts = a.filter((e): e is ArAccount => e !== undefined)
+      accounts.forEach(ac => { 
+        console.log(ac);
+        this.cache?.hydrate(ac.addr, ac); 
+      });
+      const result = accounts.find(ac => ac.handle.includes(uniqueHandle));
+      return result || null;
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ type ArAccount = {
   }
 };
 
+type GatewayConfig = {
+  host: string;
+  port: number;
+  protocol: string;
+  timeout: number;
+  logging: boolean;
+}
+
 type T_profile = {
   handleName: string;
   avatar: string;
@@ -63,4 +71,4 @@ type T_item = {
   account: ArAccount | null;
 };
 
-export type { T_addr, T_txid, T_profile, ArAccount, T_item, ArAccountEncoded };
+export type { T_addr, T_txid, T_profile, ArAccount, T_item, ArAccountEncoded, GatewayConfig };


### PR DESCRIPTION
The `AvatarURL` profile property by the library will now include the `protocol` and `port` settings of the gateway config, enabling testing of user profiles from `arlocal`.

The accuracy of `find()` results is improved when there are multiple profiles with the same handle.

🍻