### PR TITLE
Exclude anchor from search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export default class Account {
     else {
       const tx: transaction[] | block[] = await this.ardb
         .search('transactions')
+        .exclude('anchor')
         .tag('Protocol-Name', PROTOCOL_NAME)
         .from(addr)
         .limit(1)
@@ -121,6 +122,7 @@ export default class Account {
   async search(handle: string): Promise<ArAccount[]> {
     const txs: transaction[] | block[] = await this.ardb
       .search('transactions')
+      .exclude('anchor')
       .tag('Protocol-Name', PROTOCOL_NAME)
       .tag('handle', handle)
       .limit(100)
@@ -165,6 +167,7 @@ export default class Account {
     else {
       const txs: transaction[] | block[] = await this.ardb
         .search('transactions')
+        .exclude('anchor')
         .tag('Protocol-Name', PROTOCOL_NAME)
         .tag('handle', uniqueHandle.slice(0, -7))
         .limit(100)


### PR DESCRIPTION
When fetching anchor via graphql, there is chance you will get bundled transaction, which has anchor set to null until bundle is settled.  It results to fail of fetching and "default" profile as result (until bundle is settled).
```json
{
  "errors": [
    {
      "message": "Cannot return null for non-nullable field Transaction.anchor.",
      "locations": [
        {
          "line": 1,
          "column": 362
        }
      ],
      "path": [
        "transactions",
        "edges",
        0,
        "node",
        "anchor"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR"
      }
    }
  ],
  "data": null
}
``` (response from gateway)